### PR TITLE
backward-compatibility to c++11

### DIFF
--- a/include/SHA256.h
+++ b/include/SHA256.h
@@ -20,7 +20,11 @@ private:
 	uint64_t m_bitlen;
 	uint32_t m_state[8]; //A, B, C, D, E, F, G, H
 
+#if (defined(__cplusplus) && (__cplusplus < 201703L))		//backward-compatibility to c++11
+	uint32_t K [64] = {
+#else
 	static constexpr std::array<uint32_t, 64> K = {
+#endif
 		0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,
 		0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
 		0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,


### PR DESCRIPTION
Hey, I wanted to use the sha256 library in an old project with C++11 standard, so I needed to adjust this one line in the header. This could save time for others, but I completely understand if you do not want to have such code in your library. Kind regards, Hilmar