### PR TITLE
Added CMake support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 Vagrantfile
 bootstrap.sh
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(SHA256)
+
+add_library(sha256
+    src/SHA256.cpp
+)
+target_include_directories(sha256 PUBLIC "${PROJECT_SOURCE_DIR}/include")
+
+add_executable(sha256-example
+    src/main.cpp
+)
+target_include_directories(sha256-example PUBLIC "${PROJECT_SOURCE_DIR}/include")
+target_link_libraries(sha256-example sha256)


### PR DESCRIPTION
This PR adds a simple CMakeLists.txt that enables the easy use of this cool lightweight SHA256 implementation in larger, CMake based projects. :)
