### PR TITLE
Make digest() safer and easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,9 @@ b993212a26658c9077096b804cdfb92ad21cf1e199e272c44eb028e45d07b6e0
 string s = "hello world";
 SHA256 sha;
 sha.update(s);
-uint8_t * digest = sha.digest();
+std::array<uint8_t, 32> digest = sha.digest();
 
 std::cout << SHA256::toString(digest) << std::endl;
-
-delete[] digest; // Don't forget to free the digest!
 ```
 
 ## Using tipi.build to install SHA256

--- a/include/SHA256.h
+++ b/include/SHA256.h
@@ -10,9 +10,9 @@ public:
 	SHA256();
 	void update(const uint8_t * data, size_t length);
 	void update(const std::string &data);
-	uint8_t * digest();
+	std::array<uint8_t, 32> digest();
 
-	static std::string toString(const uint8_t * digest);
+	static std::string toString(const std::array<uint8_t, 32> & digest);
 
 private:
 	uint8_t  m_data[64];
@@ -46,7 +46,7 @@ private:
 	static uint32_t sig1(uint32_t x);
 	void transform();
 	void pad();
-	void revert(uint8_t * hash);
+	void revert(std::array<uint8_t, 32> & hash);
 };
 
 #endif

--- a/src/SHA256.cpp
+++ b/src/SHA256.cpp
@@ -31,8 +31,8 @@ void SHA256::update(const std::string &data) {
 	update(reinterpret_cast<const uint8_t*> (data.c_str()), data.size());
 }
 
-uint8_t * SHA256::digest() {
-	uint8_t * hash = new uint8_t[32];
+std::array<uint8_t,32> SHA256::digest() {
+	std::array<uint8_t,32> hash;
 
 	pad();
 	revert(hash);
@@ -131,7 +131,7 @@ void SHA256::pad() {
 	transform();
 }
 
-void SHA256::revert(uint8_t * hash) {
+void SHA256::revert(std::array<uint8_t, 32> & hash) {
 	// SHA uses big endian byte ordering
 	// Revert all bytes
 	for (uint8_t i = 0 ; i < 4 ; i++) {
@@ -141,7 +141,7 @@ void SHA256::revert(uint8_t * hash) {
 	}
 }
 
-std::string SHA256::toString(const uint8_t * digest) {
+std::string SHA256::toString(const std::array<uint8_t, 32> & digest) {
 	std::stringstream s;
 	s << std::setfill('0') << std::hex;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,11 +8,9 @@ int main(int argc, char ** argv) {
 	for(int i = 1 ; i < argc ; i++) {
 		SHA256 sha;
 		sha.update(argv[i]);
-		uint8_t * digest = sha.digest();
+		std::array<uint8_t, 32> digest = sha.digest();
 
 		std::cout << SHA256::toString(digest) << std::endl;
-
-		delete[] digest;
 	}
 
 	return EXIT_SUCCESS;


### PR DESCRIPTION
Make digest() return a std::array - this way, memory management is automatic, and the compiler can more easily detect out-of-bounds reads or writes.