### PR TITLE
Add workaround for undefined references

### DIFF
--- a/src/SHA256.cpp
+++ b/src/SHA256.cpp
@@ -3,6 +3,8 @@
 #include <sstream>
 #include <iomanip>
 
+constexpr std::array<uint32_t, 64> SHA256::K;
+
 SHA256::SHA256(): m_blocklen(0), m_bitlen(0) {
 	m_state[0] = 0x6a09e667;
 	m_state[1] = 0xbb67ae85;


### PR DESCRIPTION
This is needed when directly including `SHA256.cpp` in another CMake-based project, such as https://github.com/ThexXTURBOXx/ECC