### PR TITLE
Fix CMake linking issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(SHA256)
+project(sha256)
 
 add_library(sha256
     src/SHA256.cpp


### PR DESCRIPTION
Fixed CMake not linking properly with the library when used as a submodule due to a typo in `CMakeLists.txt` project declaration.